### PR TITLE
Adds support for keywords to be save and loaded

### DIFF
--- a/Assets/Card/HighlightedWords.cs
+++ b/Assets/Card/HighlightedWords.cs
@@ -46,7 +46,10 @@ public class HighlightedWords : MonoBehaviour, IPointerClickHandler
     {
         this.words = words;
         this.InitDict();
-        this.description_text.text = this.AddColorTags(this.description_text.text, this.dict_word_info);
+        if (this.description_text != null)
+        {
+            this.description_text.text = this.AddColorTags(this.description_text.text, this.dict_word_info);
+        }
     }
 
     void Awake()
@@ -178,11 +181,15 @@ public class HighlightedWords : MonoBehaviour, IPointerClickHandler
     
     /**
      * @brief Get the dictionary with the word information
-     * @reutrn The current word information dictionary
+     * @return The current word information dictionary
      */
     public Dictionary<string, WordInfo> GetDict()
     {
         return this.dict_word_info;
     }
 
+    public WordInfo[] GetDefaultWords()
+    {
+        return this.words;
+    }
 }

--- a/Assets/Scenes/Campfire.unity
+++ b/Assets/Scenes/Campfire.unity
@@ -590,6 +590,7 @@ GameObject:
   - component: {fileID: 368199149}
   - component: {fileID: 368199148}
   - component: {fileID: 368199147}
+  - component: {fileID: 368199150}
   m_Layer: 5
   m_Name: UI_Book
   m_TagString: Untagged
@@ -680,6 +681,19 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &368199150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 368199145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 220103aa289f0cd468e9dd2276de3696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BookWordInitialize
+  word_obj: {fileID: 661770109}
 --- !u!1 &426161312
 GameObject:
   m_ObjectHideFlags: 0
@@ -1368,10 +1382,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::HighlightedWords
   description_text: {fileID: 0}
   card: {fileID: 0}
-  words:
-  - {fileID: 11400000, guid: 0058ae39bc8a06b4783ac51305c60162, type: 2}
-  - {fileID: 11400000, guid: bf5464c829ef473449e58e0b517c1fe8, type: 2}
-  - {fileID: 11400000, guid: 47fadcdb5b71db54e9bec16c9b2438e4, type: 2}
+  words: []
 --- !u!114 &661770110
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -908,6 +908,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!114 &11993142
@@ -927,6 +928,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &11993145
@@ -1116,6 +1118,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &123962374
@@ -1673,6 +1676,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &224458880
@@ -1954,6 +1958,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &342202352
@@ -2022,6 +2027,7 @@ GameObject:
   - component: {fileID: 376948361}
   - component: {fileID: 376948360}
   - component: {fileID: 376948362}
+  - component: {fileID: 376948363}
   m_Layer: 5
   m_Name: UI_Book
   m_TagString: Untagged
@@ -2112,6 +2118,19 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &376948363
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376948358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 220103aa289f0cd468e9dd2276de3696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BookWordInitialize
+  word_obj: {fileID: 513039227}
 --- !u!1 &401770688 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 9156826644330562135, guid: cb2e83fba003d974a88999133bf2e816, type: 3}
@@ -2134,6 +2153,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &401770698
@@ -3082,6 +3102,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &553253033
@@ -5015,6 +5036,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &1002743207
@@ -6388,6 +6410,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &1308849405
@@ -7113,6 +7136,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &1396579130
@@ -7815,6 +7839,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &1564557393
@@ -8497,6 +8522,7 @@ MonoBehaviour:
   card_in_slot: {fileID: 0}
   card_ownership: 0
   playfieldUpgrade: {fileID: 0}
+  shopBehavior: {fileID: 0}
   gameState: {fileID: 2081642589}
   playfield: {fileID: 0}
 --- !u!65 &1931579806
@@ -9021,6 +9047,4 @@ SceneRoots:
   - {fileID: 11993129}
   - {fileID: 1949458451}
   - {fileID: 1004096598}
-  - {fileID: 406524355}
   - {fileID: 834328207}
-  - {fileID: 11993129}

--- a/Assets/Scenes/Sacrafice.unity
+++ b/Assets/Scenes/Sacrafice.unity
@@ -1088,10 +1088,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::HighlightedWords
   description_text: {fileID: 0}
   card: {fileID: 0}
-  words:
-  - {fileID: 11400000, guid: 0058ae39bc8a06b4783ac51305c60162, type: 2}
-  - {fileID: 11400000, guid: bf5464c829ef473449e58e0b517c1fe8, type: 2}
-  - {fileID: 11400000, guid: 47fadcdb5b71db54e9bec16c9b2438e4, type: 2}
+  words: []
 --- !u!114 &381156781
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1961,6 +1958,7 @@ GameObject:
   - component: {fileID: 716559621}
   - component: {fileID: 716559620}
   - component: {fileID: 716559619}
+  - component: {fileID: 716559622}
   m_Layer: 5
   m_Name: UI_Book
   m_TagString: Untagged
@@ -2051,6 +2049,19 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &716559622
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 716559617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 220103aa289f0cd468e9dd2276de3696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BookWordInitialize
+  word_obj: {fileID: 381156780}
 --- !u!1 &723690301
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Shop.unity
+++ b/Assets/Scenes/Shop.unity
@@ -2279,10 +2279,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::HighlightedWords
   description_text: {fileID: 0}
   card: {fileID: 0}
-  words:
-  - {fileID: 11400000, guid: 0058ae39bc8a06b4783ac51305c60162, type: 2}
-  - {fileID: 11400000, guid: bf5464c829ef473449e58e0b517c1fe8, type: 2}
-  - {fileID: 11400000, guid: 47fadcdb5b71db54e9bec16c9b2438e4, type: 2}
+  words: []
 --- !u!114 &1003743853
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2535,6 +2532,7 @@ GameObject:
   - component: {fileID: 1093731382}
   - component: {fileID: 1093731381}
   - component: {fileID: 1093731380}
+  - component: {fileID: 1093731383}
   m_Layer: 5
   m_Name: UI_Book
   m_TagString: Untagged
@@ -2625,6 +2623,19 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &1093731383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093731378}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 220103aa289f0cd468e9dd2276de3696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BookWordInitialize
+  word_obj: {fileID: 1003743852}
 --- !u!1 &1096864682
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SaveSystem.cs
+++ b/Assets/Scripts/SaveSystem.cs
@@ -13,6 +13,7 @@ public enum SaveSystemFile
     TotemOrders,
     OpponentDeck1,  // Example
     OpponentDeck2,  // Example, can change this to the name of the opponent
+    WordInfo,
 }
 
 
@@ -28,6 +29,9 @@ public class SaveSystem
 
     private static readonly string TOTEMS_FOLDER = "TOTEMS";
     private static readonly string TOTEMS_SAVE_LOCATION = Path.Combine(SAVES_FOLDER, TOTEMS_FOLDER);
+
+    private static readonly string WORD_INFO_FOLDER        = "WORDS";
+    private static readonly string WORD_INFO_SAVE_LOCATION = Path.Combine(SAVES_FOLDER, WORD_INFO_FOLDER);
 
     /**
      * @breif Gets the save file name for the given save file type.
@@ -50,6 +54,8 @@ public class SaveSystem
                 return "TOTEM_ORDERS.json";
             case SaveSystemFile.TotemModifierNames:
                 return "TOTEM_MODIFIER_NAMES.json";
+            case SaveSystemFile.WordInfo:
+                return "WORD_INFO.json";
 
             default:
                 // TODO(KASIN):
@@ -79,6 +85,8 @@ public class SaveSystem
                 return TOTEMS_SAVE_LOCATION;
             case SaveSystemFile.TotemOrders:
                 return TOTEMS_SAVE_LOCATION;
+            case SaveSystemFile.WordInfo:
+                return WORD_INFO_SAVE_LOCATION;
 
             default:
                 // TODO(KASIN):
@@ -498,5 +506,66 @@ public class SaveSystem
                 // TODO(ALEX):
                 throw new System.NotImplementedException();
         }
+    }
+
+
+    public static void SaveWordInfo(WordInfo[] words)
+    {
+        // TODO(KASIN): For now, each line will represent a different word.
+        //    However, this may need to be changed later.
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < words.Length; ++i)
+        {
+            string json_string = JsonUtility.ToJson(words[i]);
+            sb.Append(json_string);
+            if (i < words.Length - 1)
+            {
+                sb.Append("\n");
+            }
+        }
+        SaveToJsonFile(sb.ToString(), SaveSystemFile.WordInfo);
+    }
+
+    /**
+     * @brief Load the word information data from the save file
+     * @return The word info of cards
+     */
+    public static WordInfo[] LoadWords()
+    {
+        List<WordInfo> words = new List<WordInfo>();
+
+        // TODO(KASIN): See if this throws an execption if file does not exist...
+        StreamReader reader = null;
+        try
+        {
+            _CheckForFolderStructure(SaveSystemFile.WordInfo);
+            reader = new StreamReader(GetFullPath(SaveSystemFile.WordInfo));
+        }
+        catch (System.IO.FileNotFoundException)
+        {
+            return null;
+        }
+
+        string line = reader.ReadLine();
+        while (line != null)
+        {
+            words.Add(ScriptableObject.CreateInstance<WordInfo>());
+            JsonUtility.FromJsonOverwrite(line, words[words.Count - 1]);
+            line = reader.ReadLine();
+        }
+
+        reader.Close();
+
+        return words.ToArray();
+    }
+
+    /**
+     * @brief Check to see if the file exists.
+     * @param The file type.
+     * @return True if the file already exists. 
+     */
+    public static bool CheckForFileExistence(SaveSystemFile file)
+    {
+        return File.Exists(GetFullPath(file));
     }
 }

--- a/Assets/UI/BookWordInitialize.cs
+++ b/Assets/UI/BookWordInitialize.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public class BookWordInitialize : MonoBehaviour
+{
+    [SerializeField]
+    private HighlightedWords word_obj;
+
+    void Awake()
+    {
+        // Load the word info if it exist
+        if (SaveSystem.CheckForFileExistence(SaveSystemFile.WordInfo))
+        {
+            WordInfo[] words = SaveSystem.LoadWords();
+            word_obj.Initialize(words);
+            Debug.Log("Loaded word information from file");
+        }
+        else
+        {
+            WordInfo[] default_words = word_obj.GetDefaultWords();
+            SaveSystem.SaveWordInfo(default_words);
+            Debug.Log("Loaded default word information");
+        }
+    }
+}

--- a/Assets/UI/BookWordInitialize.cs.meta
+++ b/Assets/UI/BookWordInitialize.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 220103aa289f0cd468e9dd2276de3696


### PR DESCRIPTION
* Allows the keywords to be saved in the first battle scene to be loaded in the subsequent scenes.
* Keywords can be added to the Gameplay scene only for the UI book. The words will then be loaded via the file once the Gameplay scene as started.
Closes #98 