### PR TITLE
Adds null check for word_info

### DIFF
--- a/Assets/Card/HighlightedWords.cs
+++ b/Assets/Card/HighlightedWords.cs
@@ -32,6 +32,11 @@ public class HighlightedWords : MonoBehaviour, IPointerClickHandler
         this.dict_word_info = new Dictionary<string, WordInfo>();
         foreach (WordInfo word_info in this.words)
         {
+            if (word_info == null)
+            {
+                continue;
+            }
+
             foreach (string word in word_info.GetWords())
             {
                 this.dict_word_info[word.ToUpper()] = word_info;


### PR DESCRIPTION
* Fixes when a card has an empty element in the word info. Prevents an exception from being thrown.