### PR TITLE
Consumable upgrade / camp, sac upgraded card fix

### DIFF
--- a/Assets/Consumables/AddCardToHand/AddAnt.asset
+++ b/Assets/Consumables/AddCardToHand/AddAnt.asset
@@ -16,4 +16,3 @@ MonoBehaviour:
   icon: {fileID: 21300000, guid: c274cb913d18c1145a8c4f6f7467b908, type: 3}
   cardToAdd: {fileID: 11400000, guid: 9fabf681e1fe9544db7dadab2e2007d8, type: 2}
   cardToAdd2: {fileID: 11400000, guid: c9528b940a1906d49822f84c5967cc0e, type: 2}
-  cardToAdd3: {fileID: 11400000, guid: ed40291e8efa0bc4a9b163df1e437d7d, type: 2}

--- a/Assets/Consumables/AddCardToHand/AddAnt.asset
+++ b/Assets/Consumables/AddCardToHand/AddAnt.asset
@@ -15,3 +15,5 @@ MonoBehaviour:
   itemName: Add Ant
   icon: {fileID: 21300000, guid: c274cb913d18c1145a8c4f6f7467b908, type: 3}
   cardToAdd: {fileID: 11400000, guid: 9fabf681e1fe9544db7dadab2e2007d8, type: 2}
+  cardToAdd2: {fileID: 11400000, guid: c9528b940a1906d49822f84c5967cc0e, type: 2}
+  cardToAdd3: {fileID: 11400000, guid: ed40291e8efa0bc4a9b163df1e437d7d, type: 2}

--- a/Assets/Consumables/AddCardToHand/AddCard.cs
+++ b/Assets/Consumables/AddCardToHand/AddCard.cs
@@ -6,11 +6,15 @@ public class AddCardToHandConsumable : ScriptableObject, IConsumableSavable //in
     public string itemName;
     public Sprite icon;
     public CardData cardToAdd; //assign card, can be used for basic card like ant or flower card once added
+    public CardData cardToAdd2;
+    public CardData cardToAdd3;
 
     public void Use(Hand playerHand)
     {
         playerHand.AddCard(cardToAdd, CardOwnership.Player);
-        Debug.Log("Added to hand: " + cardToAdd.card_name);
+        playerHand.AddCard(cardToAdd2, CardOwnership.Player);
+        playerHand.AddCard(cardToAdd3, CardOwnership.Player);
+        Debug.Log("Added ant swarm");
     }
     private class SaveData
     {

--- a/Assets/Consumables/AddCardToHand/AddCard.cs
+++ b/Assets/Consumables/AddCardToHand/AddCard.cs
@@ -20,6 +20,7 @@ public class AddCardToHandConsumable : ScriptableObject, IConsumableSavable //in
         public string item_name;
         public string image_resource_path;
         public string card_to_add;
+        public string card_to_add2;
 
         public SaveData(AddCardToHandConsumable consumable)
         {
@@ -27,6 +28,7 @@ public class AddCardToHandConsumable : ScriptableObject, IConsumableSavable //in
             this.item_name = consumable.itemName;
             this.image_resource_path = consumable.icon.name;
             this.card_to_add = consumable.cardToAdd.ToJSON();
+            this.card_to_add2 = consumable.cardToAdd2.ToJSON();
         }
 
         public static SaveData FromJson(string json)
@@ -51,6 +53,7 @@ public class AddCardToHandConsumable : ScriptableObject, IConsumableSavable //in
         obj.icon = Resources.Load<Sprite>("Images/" + save_data.image_resource_path);
         obj.itemName = save_data.item_name;
         obj.cardToAdd = CardData.FromJson(save_data.card_to_add);
+        obj.cardToAdd2 = CardData.FromJson(save_data.card_to_add2);
         consumable.consumable = obj;
 
         return consumable;

--- a/Assets/Consumables/AddCardToHand/AddCard.cs
+++ b/Assets/Consumables/AddCardToHand/AddCard.cs
@@ -7,13 +7,11 @@ public class AddCardToHandConsumable : ScriptableObject, IConsumableSavable //in
     public Sprite icon;
     public CardData cardToAdd; //assign card, can be used for basic card like ant or flower card once added
     public CardData cardToAdd2;
-    public CardData cardToAdd3;
 
     public void Use(Hand playerHand)
     {
         playerHand.AddCard(cardToAdd, CardOwnership.Player);
         playerHand.AddCard(cardToAdd2, CardOwnership.Player);
-        playerHand.AddCard(cardToAdd3, CardOwnership.Player);
         Debug.Log("Added ant swarm");
     }
     private class SaveData

--- a/Assets/Consumables/DamageAll/DamageAllOpponents.asset
+++ b/Assets/Consumables/DamageAll/DamageAllOpponents.asset
@@ -14,4 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::DamageAllOpponentsConsumable
   itemName: Mass Damage
   icon: {fileID: 21300000, guid: 2399fbb601bb73549b192473a813a2d2, type: 3}
-  damageAmount: 1
+  damageAmount: 100

--- a/Assets/Consumables/HealAll/HealAllFriends.asset
+++ b/Assets/Consumables/HealAll/HealAllFriends.asset
@@ -14,4 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::HealAllPlayerCardsConsumable
   itemName: Mass Heal
   icon: {fileID: 21300000, guid: 1f08788297aac8047979e4fb22a0086d, type: 3}
-  healAmount: 1
+  healAmount: 5

--- a/Assets/Sacrafice/PlayfieldUpgrade.cs
+++ b/Assets/Sacrafice/PlayfieldUpgrade.cs
@@ -47,6 +47,22 @@ public class PlayfieldUpgrade : MonoBehaviour
         { //can only upgrade once
             return;
         }
+        if (SceneManager.GetActiveScene().name == "Sacrafice") //prevent upgraded cards from ever being placed in slot
+        {
+            if (card.GetCardData().card_name.Contains("Evolved") || card.GetCardData().card_name.Contains("Blessed"))
+            {
+                Debug.Log("Upgraded cards cannot be upgraded again");
+                return;
+            }
+        }
+        else if (SceneManager.GetActiveScene().name == "Campfire")
+        {
+            if (card.GetCardData().card_name.Contains("+"))
+            {
+                Debug.Log("Upgraded cards cannot be upgraded again");
+                return;
+            }
+        }
         slot.SetIsCardPlaced(true);
         slot.SetCard(card);
         card.transform.SetParent(this.transform);
@@ -82,11 +98,6 @@ public class PlayfieldUpgrade : MonoBehaviour
             Card c2 = slot2.GetCard();
             CardData data1 = c1.GetCardData();
             CardData data2 = c2.GetCardData();
-            if (data1.card_name.Contains("Blessed") || data1.card_name.Contains("Evolved") || data2.card_name.Contains("Blessed") || data2.card_name.Contains("Evolved"))
-            {
-                Debug.Log("Upgraded cards cannot be upgraded again");
-                return;
-            }
             CardData newData = Instantiate(data1); //will write to this data and then apply to first card
             if (data1.card_name == data2.card_name) //if they are same card double the stats
             {
@@ -123,11 +134,6 @@ public class PlayfieldUpgrade : MonoBehaviour
             }
             Card c1 = slot1.GetCard();
             CardData data1 = c1.GetCardData();
-            if (data1.card_name.Contains("+"))
-            {
-                Debug.Log("Upgraded cards cannot be upgraded again");
-                return;
-            }
             CardData newData = Instantiate(data1); //will write to this data and then apply to first card
             CardData oldData = c1.GetCardData();
             newData.attack += 2;

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -3580,9 +3580,9 @@ MonoBehaviour:
   button: {fileID: 636229830}
   overlayImage: {fileID: 1315738674}
   damageConsumable: {fileID: 0}
-  healConsumable: {fileID: 0}
+  healConsumable: {fileID: 11400000, guid: 9e3f021da77566145b86e1f75617fa87, type: 2}
   cardConsumable: {fileID: 0}
-  singleHealConsumable: {fileID: 11400000, guid: 3b69cf850a21cfb40b79436272494847, type: 2}
+  singleHealConsumable: {fileID: 0}
 --- !u!114 &636229830
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Balances consumables.

- Skull now instakills all enemies
- Heal heals all units for 5 (includes overhealth)
- Card now gives a worker ant and honeypot ant

Also makes it so you cannot place upgraded cards in slots in campfire and sacrifice, removing possibility of screwing it up