### PR TITLE
Fixes sacrifice softlock

### DIFF
--- a/Assets/Card/Card.cs
+++ b/Assets/Card/Card.cs
@@ -354,8 +354,12 @@ struct ModifierTuple
                     Debug.Log("You are currently placing a card that requires sacrifice. To cancel, click on the Cancel Sacrifice Button.");
                     return;
                 }
-        
-                this.player_hand.SetSelectedCard(this.card_ownership, this);
+                
+                if (game_state.current_turn_state == TurnStates.PlayerTurn ||
+                    game_state.current_turn_state == TurnStates.PlayerDrawCard)
+                {
+                    this.player_hand.SetSelectedCard(this.card_ownership, this);
+                }
                 break;
 
             case CardState.OnPlayfield:


### PR DESCRIPTION
* Fixes the softlock up when a player attempts to sacrifice a card during the attacking state. This commit makes it so the player can only select cards in their hand when it is the player's turn. This allows the state to be reset correctly when the player cancels a sacrifice.